### PR TITLE
Hotfix Generate password crash 

### DIFF
--- a/app/src/main/java/me/soundlocker/soundlocker/ApplicationsList.java
+++ b/app/src/main/java/me/soundlocker/soundlocker/ApplicationsList.java
@@ -38,6 +38,8 @@ public class ApplicationsList extends ListActivity {
             masterId = new BigInteger(256, random).toString(32);
             storage.saveMasterId(ApplicationsList.this.getApplicationContext(),masterId);
             storage.saveFirstBoot(ApplicationsList.this.getApplicationContext(), true);
+        } else {
+            masterId = storage.getMasterId(ApplicationsList.this.getApplicationContext());
         }
     }
 


### PR DESCRIPTION
Issue was that in the case that masterId has already been generated, an empty string was being passed rather than getting from the persistent storage.